### PR TITLE
remove unused dynamic type from ITranslation interface

### DIFF
--- a/src/loadTranslations.ts
+++ b/src/loadTranslations.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import * as gettextParser from "gettext-parser";
 
 export interface ITranslation {
-    [key: string]: string | string[];
     msgid: string;
     msgid_plural?: string;
     msgstr: string | string[];


### PR DESCRIPTION
caused TS2411 because undefined type wasn't allowed for optional type mgid_plural and msgctxt