### PR TITLE
Remove reseting scriptLoaderResources per compilation

### DIFF
--- a/src/TrlPlugin.ts
+++ b/src/TrlPlugin.ts
@@ -53,7 +53,6 @@ class TrlPlugin {
         parserHook.for("javascript/dynamic").tap(this.pluginName, parserFn);
         parserHook.for("javascript/esm").tap(this.pluginName, parserFn);
 
-        this.scriptLoaderResources = [];
         compilation.hooks.buildModule.tap(this.pluginName, this.findRawResources);
     };
 


### PR DESCRIPTION
In rare cases, not yet known when exactly, it seems MiniCssExtractPlugin.loader does trigger additional compilations resulting in reseting this.scriptLoaderResources preventing this.findRawResources to behave correctly. (.indexOf === -1 and therefore module.kwfParseRaw is not set)

Note: problem in upgraded project from kwf 3.11 to 5.3. phg